### PR TITLE
Convert `ReceiveAsync` to `Receive`

### DIFF
--- a/AkkaSut.Server/PingPongActor.cs
+++ b/AkkaSut.Server/PingPongActor.cs
@@ -7,10 +7,9 @@ public class PingPongActor : ReceiveActor
 {
     public PingPongActor()
     {
-        ReceiveAsync<PingMessage>(ping =>
+        Receive<PingMessage>(ping =>
         {
             Sender.Tell(new PongMessage("Hello " + ping.Name));
-            return Task.CompletedTask;
         });
     }
 }


### PR DESCRIPTION
eliminates unnecessary delegate allocation under the covers.